### PR TITLE
chore(eco-645): Add extra debug tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "main": "src/index.tsx",
   "dependencies": {
     "@solana/web3.js": "1.63.1",
+    "ethers": "^5.7.2",
     "react": "^18.2.0",
     "react-dom": "^17.0.2",
     "react-scripts": "^4.0.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ import {
   signMessageOnSolana,
 } from './utils';
 
-import { PhantomInjectedProvider, SupportedEVMChainIds, TLog } from './types';
+import { PhantomInjectedProvider, SupportedEVMChainIds, SupportedSolanaChainIds, TLog } from './types';
 
 import { Logs, NoProvider, Sidebar } from './components';
 import { connect, silentlyConnect } from './utils/connect';
@@ -27,6 +27,9 @@ import { setupEvents } from './utils/setupEvents';
 import { ensureEthereumChain } from './utils/ensureEthereumChain';
 import { useEthereumChainIdState } from './utils/getEthereumChain';
 import { useEthereumSelectedAddress } from './utils/getEthereumSelectedAddress';
+import ERC20Contract from './utils/requests/ethERC20';
+import ERC721Contract from './utils/requests/ethERC721';
+import ERC1155Contract from './utils/requests/ethERC1155';
 
 // =============================================================================
 // Styled Components
@@ -59,7 +62,7 @@ export type ConnectedAccounts = {
   ethereum: string | null;
 };
 
-export type ConnectedMethods =
+export type ConnectedMethod =
   | {
       chain: string;
       name: string;
@@ -71,10 +74,14 @@ export type ConnectedMethods =
       onClick: (chainId?: any) => Promise<void | boolean>;
     };
 
+export type ConnectedMethods = {
+  [chainId in SupportedEVMChainIds & SupportedSolanaChainIds]: ConnectedMethod;
+};
+
 interface Props {
   connectedAccounts: ConnectedAccounts;
   connectedEthereumChainId: SupportedEVMChainIds | undefined;
-  connectedMethods: ConnectedMethods[];
+  connectedMethods: ConnectedMethods;
   handleConnect: () => Promise<void>;
   logs: TLog[];
   clearLogs: () => void;
@@ -206,6 +213,199 @@ const useProps = (provider: PhantomInjectedProvider | null): Props => {
     },
     [provider, createLog, isEthereumChainIdReady, ethereumChainId]
   );
+  /** Approve ERC20 Token via Ethereum Provider */
+  const handleApproveERC20TokenOnEthereum = useCallback(
+    async (chainId) => {
+      // set ethereum provider to the correct chainId
+      const ready = await isEthereumChainIdReady(chainId);
+      if (!ready) return;
+      const { ethereum } = provider;
+      try {
+        const erc20Contract = new ERC20Contract(ethereum);
+
+        // send the transaction up to the network
+        const txHash = await erc20Contract.approve((ethereum as any).selectedAddress);
+
+        createLog({
+          providerType: 'ethereum',
+          status: 'info',
+          method: 'eth_sendTransaction',
+          message: `Sending transaction ${txHash} on ${ethereumChainId ? getChainName(ethereumChainId) : 'undefined'}`,
+        });
+        // poll tx status until it is confirmed in a block, fails, or 30 seconds pass
+        pollEthereumTransactionReceipt(txHash, ethereum, createLog);
+      } catch (error) {
+        createLog({
+          providerType: 'ethereum',
+          status: 'error',
+          method: 'eth_sendTransaction',
+          message: error.message,
+        });
+      }
+    },
+    [provider, createLog, isEthereumChainIdReady, ethereumChainId]
+  );
+
+  /** Revoke ERC20 Token via Ethereum Provider */
+  const handleRevokeERC20TokenOnEthereum = useCallback(
+    async (chainId) => {
+      // set ethereum provider to the correct chainId
+      const ready = await isEthereumChainIdReady(chainId);
+      if (!ready) return;
+      const { ethereum } = provider;
+      try {
+        const erc20Contract = new ERC20Contract(ethereum);
+
+        // send the transaction up to the network
+        const txHash = await erc20Contract.revoke((ethereum as any).selectedAddress);
+
+        createLog({
+          providerType: 'ethereum',
+          status: 'info',
+          method: 'eth_sendTransaction',
+          message: `Sending transaction ${txHash} on ${ethereumChainId ? getChainName(ethereumChainId) : 'undefined'}`,
+        });
+        // poll tx status until it is confirmed in a block, fails, or 30 seconds pass
+        pollEthereumTransactionReceipt(txHash, ethereum, createLog);
+      } catch (error) {
+        createLog({
+          providerType: 'ethereum',
+          status: 'error',
+          method: 'eth_sendTransaction',
+          message: error.message,
+        });
+      }
+    },
+    [provider, createLog, isEthereumChainIdReady, ethereumChainId]
+  );
+  /** Approve ERC721 Token via Ethereum Provider */
+  const handleApproveERC721TokenOnEthereum = useCallback(
+    async (chainId) => {
+      // set ethereum provider to the correct chainId
+      const ready = await isEthereumChainIdReady(chainId);
+      if (!ready) return;
+      const { ethereum } = provider;
+      try {
+        const erc721Contract = new ERC721Contract(ethereum);
+
+        // send the transaction up to the network
+        const txHash = await erc721Contract.approve((ethereum as any).selectedAddress);
+
+        createLog({
+          providerType: 'ethereum',
+          status: 'info',
+          method: 'eth_sendTransaction',
+          message: `Sending transaction ${txHash} on ${ethereumChainId ? getChainName(ethereumChainId) : 'undefined'}`,
+        });
+        // poll tx status until it is confirmed in a block, fails, or 30 seconds pass
+        pollEthereumTransactionReceipt(txHash, ethereum, createLog);
+      } catch (error) {
+        createLog({
+          providerType: 'ethereum',
+          status: 'error',
+          method: 'eth_sendTransaction',
+          message: error.message,
+        });
+      }
+    },
+    [provider, createLog, isEthereumChainIdReady, ethereumChainId]
+  );
+  /** Revoke ERC721 Token via Ethereum Provider */
+  const handleRevokeERC721TokenOnEthereum = useCallback(
+    async (chainId) => {
+      // set ethereum provider to the correct chainId
+      const ready = await isEthereumChainIdReady(chainId);
+      if (!ready) return;
+      const { ethereum } = provider;
+      try {
+        const erc721Contract = new ERC721Contract(ethereum);
+
+        // send the transaction up to the network
+        const txHash = await erc721Contract.revoke((ethereum as any).selectedAddress);
+
+        createLog({
+          providerType: 'ethereum',
+          status: 'info',
+          method: 'eth_sendTransaction',
+          message: `Sending transaction ${txHash} on ${ethereumChainId ? getChainName(ethereumChainId) : 'undefined'}`,
+        });
+        // poll tx status until it is confirmed in a block, fails, or 30 seconds pass
+        pollEthereumTransactionReceipt(txHash, ethereum, createLog);
+      } catch (error) {
+        createLog({
+          providerType: 'ethereum',
+          status: 'error',
+          method: 'eth_sendTransaction',
+          message: error.message,
+        });
+      }
+    },
+    [provider, createLog, isEthereumChainIdReady, ethereumChainId]
+  );
+  /** Approve ERC1155 Token via Ethereum Provider */
+  const handleApproveERC1155TokenOnEthereum = useCallback(
+    async (chainId) => {
+      // set ethereum provider to the correct chainId
+      const ready = await isEthereumChainIdReady(chainId);
+      if (!ready) return;
+      const { ethereum } = provider;
+      try {
+        const erc1155Contract = new ERC1155Contract(ethereum);
+
+        // send the transaction up to the network
+        const txHash = await erc1155Contract.approve((ethereum as any).selectedAddress);
+
+        createLog({
+          providerType: 'ethereum',
+          status: 'info',
+          method: 'eth_sendTransaction',
+          message: `Sending transaction ${txHash} on ${ethereumChainId ? getChainName(ethereumChainId) : 'undefined'}`,
+        });
+        // poll tx status until it is confirmed in a block, fails, or 30 seconds pass
+        pollEthereumTransactionReceipt(txHash, ethereum, createLog);
+      } catch (error) {
+        createLog({
+          providerType: 'ethereum',
+          status: 'error',
+          method: 'eth_sendTransaction',
+          message: error.message,
+        });
+      }
+    },
+    [provider, createLog, isEthereumChainIdReady, ethereumChainId]
+  );
+  /** Revoke ERC1155 Token via Ethereum Provider */
+  const handleRevokeERC1155TokenOnEthereum = useCallback(
+    async (chainId) => {
+      // set ethereum provider to the correct chainId
+      const ready = await isEthereumChainIdReady(chainId);
+      if (!ready) return;
+      const { ethereum } = provider;
+      try {
+        const erc1155Contract = new ERC1155Contract(ethereum);
+
+        // send the transaction up to the network
+        const txHash = await erc1155Contract.revoke((ethereum as any).selectedAddress);
+
+        createLog({
+          providerType: 'ethereum',
+          status: 'info',
+          method: 'eth_sendTransaction',
+          message: `Sending transaction ${txHash} on ${ethereumChainId ? getChainName(ethereumChainId) : 'undefined'}`,
+        });
+        // poll tx status until it is confirmed in a block, fails, or 30 seconds pass
+        pollEthereumTransactionReceipt(txHash, ethereum, createLog);
+      } catch (error) {
+        createLog({
+          providerType: 'ethereum',
+          status: 'error',
+          method: 'eth_sendTransaction',
+          message: error.message,
+        });
+      }
+    },
+    [provider, createLog, isEthereumChainIdReady, ethereumChainId]
+  );
 
   // /** SignMessage via Solana Provider */
   const handleSignMessageOnSolana = useCallback(async () => {
@@ -257,6 +457,88 @@ const useProps = (provider: PhantomInjectedProvider | null): Props => {
     },
     [provider, createLog, isEthereumChainIdReady]
   );
+  /** SignTypedMessage (v1) via Ethereum Provider */
+  // https://eips.ethereum.org/EIPS/eip-712
+  const handleSignTypedMessageV1OnEthereum = useCallback(
+    async (chainId) => {
+      // set ethereum provider to the correct chainId
+      const ready = await isEthereumChainIdReady(chainId);
+      if (!ready) return;
+      const { ethereum } = provider;
+      try {
+        const signedMessage = await signMessageOnEthereum(ethereum, 'v1');
+        createLog({
+          providerType: 'ethereum',
+          status: 'success',
+          method: 'eth_signTypedData',
+          message: `Message signed: ${signedMessage}`,
+        });
+        return signedMessage;
+      } catch (error) {
+        createLog({
+          providerType: 'ethereum',
+          status: 'error',
+          method: 'eth_signTypedData',
+          message: error.message,
+        });
+      }
+    },
+    [provider, createLog, isEthereumChainIdReady]
+  );
+  /** SignTypedMessage (v3) via Ethereum Provider */
+  const handleSignTypedMessageV3OnEthereum = useCallback(
+    async (chainId) => {
+      // set ethereum provider to the correct chainId
+      const ready = await isEthereumChainIdReady(chainId);
+      if (!ready) return;
+      const { ethereum } = provider;
+      try {
+        const signedMessage = await signMessageOnEthereum(ethereum, 'v3');
+        createLog({
+          providerType: 'ethereum',
+          status: 'success',
+          method: 'eth_signTypedData_v3',
+          message: `Message signed: ${signedMessage}`,
+        });
+        return signedMessage;
+      } catch (error) {
+        createLog({
+          providerType: 'ethereum',
+          status: 'error',
+          method: 'eth_signTypedData_v3',
+          message: error.message,
+        });
+      }
+    },
+    [provider, createLog, isEthereumChainIdReady]
+  );
+  /** SignTypedMessage (v4) via Ethereum Provider */
+  const handleSignTypedMessageV4OnEthereum = useCallback(
+    async (chainId) => {
+      // set ethereum provider to the correct chainId
+      const ready = await isEthereumChainIdReady(chainId);
+      if (!ready) return;
+      const { ethereum } = provider;
+      try {
+        const signedMessage = await signMessageOnEthereum(ethereum, 'v4');
+        createLog({
+          providerType: 'ethereum',
+          status: 'success',
+          method: 'eth_signTypedData_v4',
+          message: `Message signed: ${signedMessage}`,
+        });
+        return signedMessage;
+      } catch (error) {
+        createLog({
+          providerType: 'ethereum',
+          status: 'error',
+          method: 'eth_signTypedData_v4',
+          message: error.message,
+        });
+      }
+    },
+    [provider, createLog, isEthereumChainIdReady]
+  );
 
   /**
    * Disconnect from Solana
@@ -280,38 +562,99 @@ const useProps = (provider: PhantomInjectedProvider | null): Props => {
   }, [provider, createLog]);
 
   const connectedMethods = useMemo(() => {
-    return [
+    const evmMethods = [
       {
-        chain: 'solana',
-        name: 'Sign and Send Transaction',
-        onClick: handleSignAndSendTransactionOnSolana,
-      },
-      {
-        chain: 'ethereum',
         name: 'Send Transaction',
         onClick: handleSendTransactionOnEthereum,
       },
+      // EIP20: https://eips.ethereum.org/EIPS/eip-20 (transfer, approve)
+      [
+        {
+          name: 'Approve ERC20 Token',
+          onClick: handleApproveERC20TokenOnEthereum,
+        },
+        {
+          name: 'Revoke ERC20 Token',
+          onClick: handleRevokeERC20TokenOnEthereum,
+        },
+      ],
+      // EIP721: https://eips.ethereum.org/EIPS/eip-721 (approve)
+      // Approve an address to send the NFT
+      [
+        {
+          name: 'Approve ERC721 Token',
+          onClick: handleApproveERC721TokenOnEthereum,
+        },
+        {
+          name: 'Revoke ERC721 Token',
+          onClick: handleRevokeERC721TokenOnEthereum,
+        },
+      ],
+      // EIP1155: https://eips.ethereum.org/EIPS/eip-1155 (setApprovalForAll)
+      // Approve an address to send the NFT
+      [
+        {
+          name: 'Approve ERC1155 Token (all)',
+          onClick: handleApproveERC1155TokenOnEthereum,
+        },
+        {
+          name: 'Revoke ERC1155 Token (all)',
+          onClick: handleRevokeERC1155TokenOnEthereum,
+        },
+      ],
       {
-        chain: 'solana',
-        name: 'Sign Message',
-        onClick: handleSignMessageOnSolana,
-      },
-      {
-        chain: 'ethereum',
         name: 'Sign Message',
         onClick: handleSignMessageOnEthereum,
       },
-      {
-        chain: 'solana',
-        name: 'Disconnect',
-        onClick: handleDisconnect,
-      },
+      [
+        {
+          name: 'Sign Typed Message (v1)',
+          onClick: handleSignTypedMessageV1OnEthereum,
+        },
+        {
+          name: 'Sign Typed Message (v3)',
+          onClick: handleSignTypedMessageV3OnEthereum,
+        },
+        {
+          name: 'Sign Typed Message (v4)',
+          onClick: handleSignTypedMessageV4OnEthereum,
+        },
+      ],
     ];
+
+    return {
+      [SupportedEVMChainIds.EthereumGoerli]: evmMethods,
+      [SupportedEVMChainIds.PolygonMainnet]: evmMethods,
+      [SupportedSolanaChainIds.SolanaMainnet]: [
+        {
+          name: 'Sign and Send Transaction',
+          onClick: handleSignAndSendTransactionOnSolana,
+        },
+
+        {
+          name: 'Sign Message',
+          onClick: handleSignMessageOnSolana,
+        },
+        {
+          name: 'Disconnect',
+          onClick: handleDisconnect,
+        },
+      ],
+    };
   }, [
     handleSignAndSendTransactionOnSolana,
     handleSendTransactionOnEthereum,
     handleSignMessageOnSolana,
     handleSignMessageOnEthereum,
+    handleApproveERC20TokenOnEthereum,
+    handleApproveERC721TokenOnEthereum,
+    handleApproveERC1155TokenOnEthereum,
+    handleRevokeERC20TokenOnEthereum,
+    handleRevokeERC721TokenOnEthereum,
+    handleRevokeERC1155TokenOnEthereum,
+    handleSignTypedMessageV1OnEthereum,
+    handleSignTypedMessageV3OnEthereum,
+    handleSignTypedMessageV4OnEthereum,
     handleDisconnect,
   ]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import { useEthereumSelectedAddress } from './utils/getEthereumSelectedAddress';
 import ERC20Contract from './utils/requests/ethERC20';
 import ERC721Contract from './utils/requests/ethERC721';
 import ERC1155Contract from './utils/requests/ethERC1155';
+import signTypedMessageOnEthereum from './utils/signTypedMessageOnEthereum';
 
 // =============================================================================
 // Styled Components
@@ -466,7 +467,7 @@ const useProps = (provider: PhantomInjectedProvider | null): Props => {
       if (!ready) return;
       const { ethereum } = provider;
       try {
-        const signedMessage = await signMessageOnEthereum(ethereum, 'v1');
+        const signedMessage = await signTypedMessageOnEthereum(ethereum, 'v1');
         createLog({
           providerType: 'ethereum',
           status: 'success',
@@ -493,7 +494,7 @@ const useProps = (provider: PhantomInjectedProvider | null): Props => {
       if (!ready) return;
       const { ethereum } = provider;
       try {
-        const signedMessage = await signMessageOnEthereum(ethereum, 'v3');
+        const signedMessage = await signTypedMessageOnEthereum(ethereum, 'v3');
         createLog({
           providerType: 'ethereum',
           status: 'success',
@@ -520,7 +521,7 @@ const useProps = (provider: PhantomInjectedProvider | null): Props => {
       if (!ready) return;
       const { ethereum } = provider;
       try {
-        const signedMessage = await signMessageOnEthereum(ethereum, 'v4');
+        const signedMessage = await signTypedMessageOnEthereum(ethereum, 'v4');
         createLog({
           providerType: 'ethereum',
           status: 'success',
@@ -533,6 +534,34 @@ const useProps = (provider: PhantomInjectedProvider | null): Props => {
           providerType: 'ethereum',
           status: 'error',
           method: 'eth_signTypedData_v4',
+          message: error.message,
+        });
+      }
+    },
+    [provider, createLog, isEthereumChainIdReady]
+  );
+
+  /** SignTypedMessage (v4) via Ethereum Provider using ethers.js */
+  const handleSignTypedMessageWithEthersOnEthereum = useCallback(
+    async (chainId) => {
+      // set ethereum provider to the correct chainId
+      const ready = await isEthereumChainIdReady(chainId);
+      if (!ready) return;
+      const { ethereum } = provider;
+      try {
+        const signedMessage = await signTypedMessageOnEthereum(ethereum, 'ethers');
+        createLog({
+          providerType: 'ethereum',
+          status: 'success',
+          method: 'eth_signTypedData',
+          message: `Message signed: ${signedMessage}`,
+        });
+        return signedMessage;
+      } catch (error) {
+        createLog({
+          providerType: 'ethereum',
+          status: 'error',
+          method: 'eth_signTypedData',
           message: error.message,
         });
       }
@@ -619,6 +648,10 @@ const useProps = (provider: PhantomInjectedProvider | null): Props => {
           name: 'Sign Typed Message (v4)',
           onClick: handleSignTypedMessageV4OnEthereum,
         },
+        {
+          name: 'Sign Typed Message (ethers)',
+          onClick: handleSignTypedMessageWithEthersOnEthereum,
+        },
       ],
     ];
 
@@ -655,6 +688,7 @@ const useProps = (provider: PhantomInjectedProvider | null): Props => {
     handleSignTypedMessageV1OnEthereum,
     handleSignTypedMessageV3OnEthereum,
     handleSignTypedMessageV4OnEthereum,
+    handleSignTypedMessageWithEthersOnEthereum,
     handleDisconnect,
   ]);
 

--- a/src/components/Logs/index.tsx
+++ b/src/components/Logs/index.tsx
@@ -20,6 +20,21 @@ const StyledSection = styled.section`
   background-color: ${BLACK};
   overflow: auto;
   font-family: monospace;
+  box-sizing: border-box;
+
+  @media (max-width: 768px) {
+    flex: initial;
+    flex-basis: 150px !important;
+  }
+`;
+
+const LogsContainer = styled.div`
+  @media (max-width: 768px) {
+    overflow: auto;
+    height: 110px;
+    display: flex;
+    flex-direction: column;
+  }
 `;
 
 const ClearLogsButton = styled(Button)`
@@ -63,9 +78,11 @@ const Logs = React.memo((props: Props) => {
     <StyledSection>
       {logs.length > 0 ? (
         <>
-          {logs.map((log, i) => (
-            <Log key={`${log.status}-${log.method}-${i}`} {...log} />
-          ))}
+          <LogsContainer>
+            {logs.map((log, i) => (
+              <Log key={`${log.status}-${log.method}-${i}`} {...log} />
+            ))}
+          </LogsContainer>
           <ClearLogsButton onClick={clearLogs}>Clear Logs</ClearLogsButton>
         </>
       ) : (

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -5,7 +5,7 @@ import { DARK_GRAY, GRAY, LIGHT_GRAY, PURPLE, REACT_GRAY, WHITE } from '../../co
 import { hexToRGB } from '../../utils';
 import Button from '../Button';
 import { ConnectedAccounts, ConnectedMethods } from '../../App';
-import { SupportedChainIcons, SupportedChainNames, SupportedEVMChainIds } from '../../types';
+import { SupportedChainIcons, SupportedChainNames, SupportedEVMChainIds, SupportedSolanaChainIds } from '../../types';
 
 // =============================================================================
 // Styled Components
@@ -20,6 +20,9 @@ const Main = styled.main`
   padding: 20px;
   align-items: center;
   background-color: ${REACT_GRAY};
+  box-sizing: border-box;
+  height: 100vh;
+  max-height: 100vh;
 
   > * {
     margin-bottom: 10px;
@@ -35,6 +38,9 @@ const Body = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  box-sizing: border-box;
+  flex: 1;
+  max-height: 100%;
 
   button {
     margin-bottom: 15px;
@@ -193,12 +199,20 @@ const ChainHeader = styled.div`
   margin: 5px 0 10px;
 `;
 
+const ButtonRow = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+`;
+
 // =============================================================================
 // Typedefs
 // =============================================================================
 
 interface Props {
-  connectedMethods: ConnectedMethods[];
+  connectedMethods: ConnectedMethods;
   connectedEthereumChainId: SupportedEVMChainIds | null;
   connectedAccounts: ConnectedAccounts;
   connect: () => Promise<void>;
@@ -208,12 +222,30 @@ interface Props {
 // Main Component
 // =============================================================================
 const Sidebar = React.memo((props: Props) => {
+  function renderConnectedMethods(methods, chainId) {
+    return methods.map((method, i) => {
+      if (Array.isArray(method)) {
+        return <ButtonRow>{renderConnectedMethods(method, chainId)}</ButtonRow>;
+      }
+
+      return (
+        <Button
+          data-test-id={`${chainId}-${method.name}`}
+          key={`${method.name}-${i}`}
+          onClick={() => method.onClick(chainId)}
+        >
+          {method.name}
+        </Button>
+      );
+    });
+  }
+
   const { connectedAccounts, connectedEthereumChainId, connectedMethods, connect } = props;
   return (
     <Main>
       <Body>
         <Link>
-          <img src='https://phantom.app/img/phantom-logo.svg' alt='Phantom' width='200' />
+          <img src="https://phantom.app/img/phantom-logo.svg" alt="Phantom" width="200" />
           <Subtitle>Multi-chain Sandbox</Subtitle>
         </Link>
         {connectedAccounts?.solana ? (
@@ -222,87 +254,78 @@ const Sidebar = React.memo((props: Props) => {
             <div>
               <Pre>Connected as</Pre>
               <AccountRow>
-                <ChainIcon src={SupportedChainIcons.Ethereum} height='36px' />
+                <ChainIcon src={SupportedChainIcons.Ethereum} height="36px" />
                 <Badge>{connectedAccounts?.ethereum}</Badge>
               </AccountRow>
               <AccountRow>
-                <ChainIcon src={SupportedChainIcons.Polygon} height='36px' />
+                <ChainIcon src={SupportedChainIcons.Polygon} height="36px" />
                 <Badge>{connectedAccounts?.ethereum}</Badge>
               </AccountRow>
               <AccountRow>
-                <ChainIcon src={SupportedChainIcons.Solana} height='36px' />
+                <ChainIcon src={SupportedChainIcons.Solana} height="36px" />
                 <Badge>{connectedAccounts?.solana?.toBase58()}</Badge>
               </AccountRow>
               <Divider />
             </div>
-            <ChainHeader>
-              <ChainIcon
-                src={SupportedChainIcons.Ethereum}
-                height='16px'
-                style={{ marginRight: '6px', borderRadius: '6px' }}
-              />
-              <Tag>{SupportedChainNames.EthereumGoerli}</Tag>
-            </ChainHeader>
-            {connectedMethods
-              .filter((method) => method.chain === 'ethereum')
-              .map((method, i) => (
-                <Button data-test-id={`ethereum-goerli-${method.name}`}
-                        key={`${method.name}-${i}`}
-                        onClick={() => method.onClick(SupportedEVMChainIds.EthereumGoerli)}>
-                  {method.name}
-                </Button>
-              ))}
-            <ChainHeader>
-              <ChainIcon
-                src={SupportedChainIcons.Polygon}
-                height='16px'
-                style={{ marginRight: '6px', borderRadius: '6px' }}
-              />
-              <Tag>{SupportedChainNames.PolygonMainnet}</Tag>
-            </ChainHeader>
-            {connectedMethods
-              .filter((method) => method.chain === 'ethereum')
-              .map((method, i) => (
-                <Button
-                  data-test-id={`polygon-mainnet-${method.name}`}
-                  key={`${method.name}-${i}`}
-                  onClick={() => method.onClick(SupportedEVMChainIds.PolygonMainnet)}
-                >
-                  {method.name}
-                </Button>
-              ))}
-            <ChainHeader>
-              <ChainIcon
-                src={SupportedChainIcons.Solana}
-                height='16px'
-                style={{ marginRight: '6px', borderRadius: '6px' }}
-              />
-              <Tag>{SupportedChainNames.SolanaMainnet}</Tag>
-            </ChainHeader>
-            {connectedMethods
-              .filter((method) => method.chain === 'solana')
-              .map((method, i) => (
-                <Button
-                  data-test-id={`solana-${method.name}`}
-                  key={`${method.name}-${i}`} onClick={method.onClick}>
-                  {method.name}
-                </Button>
-              ))}
+
+            <div style={{ overflowY: 'scroll' }}>
+              {/* Ethereum Goerli */}
+              <ChainHeader>
+                <ChainIcon
+                  src={SupportedChainIcons.Ethereum}
+                  height="16px"
+                  style={{ marginRight: '6px', borderRadius: '6px' }}
+                />
+                <Tag>{SupportedChainNames.EthereumGoerli}</Tag>
+              </ChainHeader>
+              {renderConnectedMethods(
+                connectedMethods[SupportedEVMChainIds.EthereumGoerli],
+                SupportedEVMChainIds.EthereumGoerli
+              )}
+
+              {/* Polygon Mainnet */}
+              <ChainHeader>
+                <ChainIcon
+                  src={SupportedChainIcons.Polygon}
+                  height="16px"
+                  style={{ marginRight: '6px', borderRadius: '6px' }}
+                />
+                <Tag>{SupportedChainNames.PolygonMainnet}</Tag>
+              </ChainHeader>
+              {renderConnectedMethods(
+                connectedMethods[SupportedEVMChainIds.PolygonMainnet],
+                SupportedEVMChainIds.PolygonMainnet
+              )}
+
+              {/* Solana */}
+              <ChainHeader>
+                <ChainIcon
+                  src={SupportedChainIcons.Solana}
+                  height="16px"
+                  style={{ marginRight: '6px', borderRadius: '6px' }}
+                />
+                <Tag>{SupportedChainNames.SolanaMainnet}</Tag>
+              </ChainHeader>
+              {renderConnectedMethods(
+                connectedMethods[SupportedSolanaChainIds.SolanaMainnet],
+                SupportedSolanaChainIds.SolanaMainnet
+              )}
+            </div>
           </>
         ) : (
           // not connected
-          <Button data-testid='connect-to-phantom' onClick={connect} style={{ marginTop: '15px' }}>
+          <Button data-testid="connect-to-phantom" onClick={connect} style={{ marginTop: '15px' }}>
             Connect to Phantom
           </Button>
         )}
       </Body>
       {/* 😊 💕  */}
-      <Tag>
+      <Tag style={{ marginTop: -16 }}>
         Made with{' '}
-        <span role='img' aria-label='Red Heart Emoji'>
+        <span role="img" aria-label="Red Heart Emoji">
           ❤️
         </span>{' '}
-        by the <a href='https://phantom.app'>Phantom</a> team
+        by the <a href="https://phantom.app">Phantom</a> team
       </Tag>
     </Main>
   );

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -32,6 +32,10 @@ const Main = styled.main`
   @media (max-width: 768px) {
     width: 100%;
     height: auto;
+    flex: 1;
+    position: unset;
+    max-height: auto;
+    overflow: scroll;
   }
 `;
 

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -23,6 +23,7 @@ const Main = styled.main`
   box-sizing: border-box;
   height: 100vh;
   max-height: 100vh;
+  padding-bottom: 46px;
 
   > * {
     margin-bottom: 10px;
@@ -268,7 +269,7 @@ const Sidebar = React.memo((props: Props) => {
               <Divider />
             </div>
 
-            <div style={{ overflowY: 'scroll' }}>
+            <div style={{ overflowY: 'scroll', paddingRight: 16 }}>
               {/* Ethereum Goerli */}
               <ChainHeader>
                 <ChainIcon
@@ -320,7 +321,7 @@ const Sidebar = React.memo((props: Props) => {
         )}
       </Body>
       {/* 😊 💕  */}
-      <Tag style={{ marginTop: -16 }}>
+      <Tag>
         Made with{' '}
         <span role="img" aria-label="Red Heart Emoji">
           ❤️

--- a/src/static/abis/erc1155.abi.json
+++ b/src/static/abis/erc1155.abi.json
@@ -1,0 +1,314 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "ids",
+        "type": "uint256[]"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256[]",
+        "name": "values",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "TransferBatch",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "TransferSingle",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "value",
+        "type": "string"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "URI",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "accounts",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "ids",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "balanceOfBatch",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "ids",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeBatchTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      }
+    ],
+    "name": "uri",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/static/abis/erc20.abi.json
+++ b/src/static/abis/erc20.abi.json
@@ -1,0 +1,222 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_spender",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "name": "_spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  }
+]

--- a/src/static/abis/erc721.abi.json
+++ b/src/static/abis/erc721.abi.json
@@ -1,0 +1,297 @@
+[
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "approved",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ownerOf",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getApproved",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,9 @@ type EthereumRequestMethod =
   | 'eth_getTransactionReceipt'
   | 'eth_sendTransaction'
   | 'eth_requestAccounts'
+  | 'eth_signTypedData'
+  | 'eth_signTypedData_v3'
+  | 'eth_signTypedData_v4'
   | 'personal_sign'
   | 'eth_accounts'
   | 'eth_chainId'
@@ -39,11 +42,11 @@ export interface PhantomSolanaProvider {
   isConnected: boolean | null;
   signAndSendTransaction: (
     transaction: Transaction | VersionedTransaction,
-    opts?: SendOptions,
+    opts?: SendOptions
   ) => Promise<{ signature: string; publicKey: PublicKey }>;
   signTransaction: (transaction: Transaction | VersionedTransaction) => Promise<Transaction | VersionedTransaction>;
   signAllTransactions: (
-    transactions: (Transaction | VersionedTransaction)[],
+    transactions: (Transaction | VersionedTransaction)[]
   ) => Promise<(Transaction | VersionedTransaction)[]>;
   signMessage: (message: Uint8Array | string, display?: DisplayEncoding) => Promise<any>;
   connect: (opts?: Partial<SolanaConnectOptions>) => Promise<{ publicKey: PublicKey }>;

--- a/src/utils/requests/ethERC1155.ts
+++ b/src/utils/requests/ethERC1155.ts
@@ -1,0 +1,33 @@
+import { PhantomEthereumProvider } from '../../types';
+import { ethers } from 'ethers';
+import erc1155ABI from '../../static/abis/erc1155.abi.json';
+
+class ERC1155Contract {
+  private contract;
+
+  constructor(provider: PhantomEthereumProvider) {
+    // RTFKT X Nike: https://etherscan.io/token/0x6d4bbc0387dd4759eee30f6a482ac6dc2df3facf
+    const ethersProvider = new ethers.providers.Web3Provider(provider as ethers.providers.ExternalProvider);
+    this.contract = new ethers.Contract(
+      '0x6d4bbc0387dd4759eee30f6a482ac6dc2df3facf',
+      erc1155ABI,
+      ethersProvider.getSigner()
+    );
+  }
+
+  async approve(address, amount = 1) {
+    try {
+      const txHash = await this.contract.approve(address, amount);
+      if (typeof txHash === 'string') return txHash;
+      throw new Error('did not get back a transaction hash');
+    } catch (error) {
+      console.warn(error);
+      throw new Error(error.message);
+    }
+  }
+
+  async revoke(address) {
+    return this.approve(address, 0);
+  }
+}
+export default ERC1155Contract;

--- a/src/utils/requests/ethERC20.ts
+++ b/src/utils/requests/ethERC20.ts
@@ -1,0 +1,33 @@
+import { PhantomEthereumProvider } from '../../types';
+import { ethers } from 'ethers';
+import erc20ABI from '../../static/abis/erc20.abi.json';
+
+class ERC20Contract {
+  private contract;
+
+  constructor(provider: PhantomEthereumProvider) {
+    // SUSHI: https://etherscan.io/token/0x6b3595068778dd592e39a122f4f5a5cf09c90fe2
+    const ethersProvider = new ethers.providers.Web3Provider(provider as ethers.providers.ExternalProvider);
+    this.contract = new ethers.Contract(
+      '0x6b3595068778dd592e39a122f4f5a5cf09c90fe2',
+      erc20ABI,
+      ethersProvider.getSigner()
+    );
+  }
+
+  async approve(address, amount = 1) {
+    try {
+      const txHash = await this.contract.approve(address, amount);
+      if (typeof txHash === 'string') return txHash;
+      throw new Error('did not get back a transaction hash');
+    } catch (error) {
+      console.warn(error);
+      throw new Error(error.message);
+    }
+  }
+
+  async revoke(address) {
+    return this.approve(address, 0);
+  }
+}
+export default ERC20Contract;

--- a/src/utils/requests/ethERC721.ts
+++ b/src/utils/requests/ethERC721.ts
@@ -1,0 +1,33 @@
+import { PhantomEthereumProvider } from '../../types';
+import { ethers } from 'ethers';
+import erc721ABI from '../../static/abis/erc721.abi.json';
+
+class ERC721Contract {
+  private contract;
+
+  constructor(provider: PhantomEthereumProvider) {
+    // BAYC: https://etherscan.io/token/0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d
+    const ethersProvider = new ethers.providers.Web3Provider(provider as ethers.providers.ExternalProvider);
+    this.contract = new ethers.Contract(
+      '0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d',
+      erc721ABI,
+      ethersProvider.getSigner()
+    );
+  }
+
+  async approve(address, amount = 1) {
+    try {
+      const txHash = await this.contract.approve(address, amount);
+      if (typeof txHash === 'string') return txHash;
+      throw new Error('did not get back a transaction hash');
+    } catch (error) {
+      console.warn(error);
+      throw new Error(error.message);
+    }
+  }
+
+  async revoke(address) {
+    return this.approve(address, 0);
+  }
+}
+export default ERC721Contract;

--- a/src/utils/sendTransactionOnEthereum.ts
+++ b/src/utils/sendTransactionOnEthereum.ts
@@ -29,7 +29,7 @@ const sendTransactionOnEthereum = async (
   try {
     const transactionParameters = await getTransactionParameters();
     const ethersProvider = new ethers.providers.Web3Provider(provider as ethers.providers.ExternalProvider);
-    const txHash = ethersProvider.send('eth_sendTransaction', [transactionParameters]);
+    const txHash = await ethersProvider.send('eth_sendTransaction', [transactionParameters]);
     if (typeof txHash === 'string') return txHash;
     throw new Error('did not get back a transaction hash');
   } catch (error) {

--- a/src/utils/sendTransactionOnEthereum.ts
+++ b/src/utils/sendTransactionOnEthereum.ts
@@ -1,31 +1,35 @@
 import { PhantomEthereumProvider } from '../types';
 import numToHexString from './numToHexString';
 import { getEthereumSelectedAddress } from './getEthereumSelectedAddress';
+import { ethers } from 'ethers';
 
 /**
  * Sends a transaction of 1 wei to yourself
  * @param provider a Phantom ethereum provider
+ * @param getTransactionParameters returns a Promise of the transaction parameters that will be sent to the transaction
  * @returns a transaction hash
  */
-const sendTransactionOnEthereum = async (provider: PhantomEthereumProvider): Promise<string> => {
-  try {
+const sendTransactionOnEthereum = async (
+  provider: PhantomEthereumProvider,
+  getTransactionParameters = async () => {
     const selectedAddress = await getEthereumSelectedAddress(provider);
     /**
      * Required parameters for a simple transfer of 1 wei
      * Phantom will automatically handle nonce & chainId.
      * gasPrice will be handled by Phantom and customizable by end users during confirmation
      */
-    const transactionParameters = {
+    return {
       from: selectedAddress, // must match user's active address
       to: selectedAddress, // required except during contract publications
       gas: numToHexString(30000), // the max amount of gas to be used in the tx
       value: numToHexString(1), // only required when transferring ether. in this case, send 1 wei
     };
-
-    const txHash = await provider.request({
-      method: 'eth_sendTransaction',
-      params: [transactionParameters],
-    });
+  }
+): Promise<string> => {
+  try {
+    const transactionParameters = await getTransactionParameters();
+    const ethersProvider = new ethers.providers.Web3Provider(provider as ethers.providers.ExternalProvider);
+    const txHash = ethersProvider.send('eth_sendTransaction', [transactionParameters]);
     if (typeof txHash === 'string') return txHash;
     throw new Error('did not get back a transaction hash');
   } catch (error) {

--- a/src/utils/signTypedMessageOnEthereum.ts
+++ b/src/utils/signTypedMessageOnEthereum.ts
@@ -75,10 +75,11 @@ const msgParams = {
   },
 };
 
+// https://eips.ethereum.org/EIPS/eip-712#specification-of-the-web3-api
 const signTypedMessageV1 = async (selectedAddress: string, provider: PhantomEthereumProvider) => {
   return provider.request({
     method: 'eth_signTypedData',
-    params: [selectedAddress, msgParams],
+    params: [msgParams, selectedAddress],
   });
 };
 

--- a/src/utils/signTypedMessageOnEthereum.ts
+++ b/src/utils/signTypedMessageOnEthereum.ts
@@ -1,0 +1,98 @@
+import { ethers } from 'ethers';
+import { PhantomEthereumProvider } from '../types';
+import { getEthereumSelectedAddress } from './getEthereumSelectedAddress';
+
+/**
+ * Signs a message on Ethereum
+ * @param provider a Phantom ethereum provider
+ * @param message a message to sign
+ * @returns a signed message is hex string format
+ */
+const signTypedMessageOnEthereum = async (
+  version: 'v1' | 'v3' | 'v4',
+  provider: PhantomEthereumProvider
+): Promise<string> => {
+  try {
+    const selectedAddress = await getEthereumSelectedAddress(provider);
+
+    let signedMessage;
+
+    switch (version) {
+      case 'v1':
+        signedMessage = await signTypedMessageV1(selectedAddress, provider);
+        break;
+      case 'v3':
+        signedMessage = await signTypedMessageV3(selectedAddress, provider);
+        break;
+      case 'v4':
+        signedMessage = await signTypedMessageV4(provider);
+        break;
+    }
+
+    if (typeof signedMessage === 'string') return signedMessage;
+    throw new Error('personal_sign did not respond with a signature');
+  } catch (error) {
+    console.warn(error);
+    throw new Error(error.message);
+  }
+};
+
+const msgParams = {
+  types: {
+    EIP712Domain: [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+    ],
+    Person: [
+      { name: 'name', type: 'string' },
+      { name: 'wallet', type: 'address' },
+    ],
+    Mail: [
+      { name: 'from', type: 'Person' },
+      { name: 'to', type: 'Person' },
+      { name: 'contents', type: 'string' },
+    ],
+  },
+  primaryType: 'Mail',
+  domain: {
+    name: 'Ether Mail',
+    version: '1',
+    chainId: 1,
+    verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
+  },
+  message: {
+    from: {
+      name: 'Cow',
+      wallet: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+    },
+    to: {
+      name: 'Bob',
+      wallet: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB',
+    },
+    contents: 'Hello, Bob!',
+  },
+};
+
+const signTypedMessageV1 = async (selectedAddress: string, provider: PhantomEthereumProvider) => {
+  return provider.request({
+    method: 'eth_signTypedData',
+    params: [selectedAddress, msgParams],
+  });
+};
+
+// https://eips.ethereum.org/assets/eip-712/Example.js
+const signTypedMessageV3 = async (selectedAddress: string, provider: PhantomEthereumProvider) => {
+  return provider.request({
+    method: 'eth_signTypedData_v3',
+    params: [selectedAddress, msgParams],
+  });
+};
+
+const signTypedMessageV4 = async (provider: PhantomEthereumProvider) => {
+  const ethersProvider = new ethers.providers.Web3Provider(provider as ethers.providers.ExternalProvider);
+  return ethersProvider.getSigner()._signTypedData(msgParams.domain, msgParams.types, msgParams.message);
+};
+
+export default signTypedMessageOnEthereum;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1147,6 +1147,348 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@ethersproject/abi@5.7.0", "@ethersproject/abi@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.7.0.tgz#b3f3e045bbbeed1af3947335c247ad625a44e449"
+  integrity sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==
+  dependencies:
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/abstract-provider@5.7.0", "@ethersproject/abstract-provider@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz#b0a8550f88b6bf9d51f90e4795d48294630cb9ef"
+  integrity sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+
+"@ethersproject/abstract-signer@5.7.0", "@ethersproject/abstract-signer@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz#13f4f32117868452191a4649723cb086d2b596b2"
+  integrity sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+
+"@ethersproject/address@5.7.0", "@ethersproject/address@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz#19b56c4d74a3b0a46bfdbb6cfcc0a153fc697f37"
+  integrity sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+
+"@ethersproject/base64@5.7.0", "@ethersproject/base64@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.7.0.tgz#ac4ee92aa36c1628173e221d0d01f53692059e1c"
+  integrity sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+
+"@ethersproject/basex@5.7.0", "@ethersproject/basex@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.7.0.tgz#97034dc7e8938a8ca943ab20f8a5e492ece4020b"
+  integrity sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+
+"@ethersproject/bignumber@5.7.0", "@ethersproject/bignumber@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
+  integrity sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    bn.js "^5.2.1"
+
+"@ethersproject/bytes@5.7.0", "@ethersproject/bytes@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
+  integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/constants@5.7.0", "@ethersproject/constants@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
+  integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+
+"@ethersproject/contracts@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.7.0.tgz#c305e775abd07e48aa590e1a877ed5c316f8bd1e"
+  integrity sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==
+  dependencies:
+    "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+
+"@ethersproject/hash@5.7.0", "@ethersproject/hash@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.7.0.tgz#eb7aca84a588508369562e16e514b539ba5240a7"
+  integrity sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/hdnode@5.7.0", "@ethersproject/hdnode@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.7.0.tgz#e627ddc6b466bc77aebf1a6b9e47405ca5aef9cf"
+  integrity sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/basex" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/pbkdf2" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/wordlists" "^5.7.0"
+
+"@ethersproject/json-wallets@5.7.0", "@ethersproject/json-wallets@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz#5e3355287b548c32b368d91014919ebebddd5360"
+  integrity sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/hdnode" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/pbkdf2" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
+"@ethersproject/keccak256@5.7.0", "@ethersproject/keccak256@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz#3186350c6e1cd6aba7940384ec7d6d9db01f335a"
+  integrity sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    js-sha3 "0.8.0"
+
+"@ethersproject/logger@5.7.0", "@ethersproject/logger@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
+  integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
+
+"@ethersproject/networks@5.7.1", "@ethersproject/networks@^5.7.0":
+  version "5.7.1"
+  resolved "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.7.1.tgz#118e1a981d757d45ccea6bb58d9fd3d9db14ead6"
+  integrity sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/pbkdf2@5.7.0", "@ethersproject/pbkdf2@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz#d2267d0a1f6e123f3771007338c47cccd83d3102"
+  integrity sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+
+"@ethersproject/properties@5.7.0", "@ethersproject/properties@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.7.0.tgz#a6e12cb0439b878aaf470f1902a176033067ed30"
+  integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/providers@5.7.2":
+  version "5.7.2"
+  resolved "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.7.2.tgz#f8b1a4f275d7ce58cf0a2eec222269a08beb18cb"
+  integrity sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/basex" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+    bech32 "1.1.4"
+    ws "7.4.6"
+
+"@ethersproject/random@5.7.0", "@ethersproject/random@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/random/-/random-5.7.0.tgz#af19dcbc2484aae078bb03656ec05df66253280c"
+  integrity sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/rlp@5.7.0", "@ethersproject/rlp@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz#de39e4d5918b9d74d46de93af80b7685a9c21304"
+  integrity sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/sha2@5.7.0", "@ethersproject/sha2@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.7.0.tgz#9a5f7a7824ef784f7f7680984e593a800480c9fb"
+  integrity sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@5.7.0", "@ethersproject/signing-key@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.7.0.tgz#06b2df39411b00bc57c7c09b01d1e41cf1b16ab3"
+  integrity sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    bn.js "^5.2.1"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/solidity@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz#5e9c911d8a2acce2a5ebb48a5e2e0af20b631cb8"
+  integrity sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/strings@5.7.0", "@ethersproject/strings@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz#54c9d2a7c57ae8f1205c88a9d3a56471e14d5ed2"
+  integrity sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/transactions@5.7.0", "@ethersproject/transactions@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz#91318fc24063e057885a6af13fdb703e1f993d3b"
+  integrity sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==
+  dependencies:
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
+
+"@ethersproject/units@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz#637b563d7e14f42deeee39245275d477aae1d8b1"
+  integrity sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/wallet@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.7.0.tgz#4e5d0790d96fe21d61d38fb40324e6c7ef350b2d"
+  integrity sha512-MhmXlJXEJFBFVKrDLB4ZdDzxcBxQ3rLyCkhNqVu3CDYvR97E+8r01UgrI+TI99Le+aYm/in/0vp86guJuM7FCA==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/hdnode" "^5.7.0"
+    "@ethersproject/json-wallets" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/wordlists" "^5.7.0"
+
+"@ethersproject/web@5.7.1", "@ethersproject/web@^5.7.0":
+  version "5.7.1"
+  resolved "https://registry.npmjs.org/@ethersproject/web/-/web-5.7.1.tgz#de1f285b373149bee5928f4eb7bcb87ee5fbb4ae"
+  integrity sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==
+  dependencies:
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/wordlists@5.7.0", "@ethersproject/wordlists@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.7.0.tgz#8fb2c07185d68c3e09eb3bfd6e779ba2774627f5"
+  integrity sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
 "@gar/promisify@^1.0.1":
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
@@ -2280,6 +2622,11 @@ adjust-sourcemap-loader@3.0.0:
     loader-utils "^2.0.0"
     regex-parser "^2.2.11"
 
+aes-js@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
+  integrity sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==
+
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -2853,6 +3200,11 @@ batch@0.6.1:
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==
 
+bech32@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
+  integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
+
 bfj@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/bfj/-/bfj-7.0.2.tgz#1988ce76f3add9ac2913fd8ba47aad9e651bfbb2"
@@ -2902,7 +3254,7 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
 
-bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.2.0:
+bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.2.0, bn.js@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
   integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
@@ -4381,7 +4733,7 @@ electron-to-chromium@^1.3.564, electron-to-chromium@^1.4.251:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz#61046d1e4cab3a25238f6bf7413795270f125592"
   integrity sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==
 
-elliptic@^6.5.3:
+elliptic@6.5.4, elliptic@^6.5.3:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
@@ -4867,6 +5219,42 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
+
+ethers@^5.7.2:
+  version "5.7.2"
+  resolved "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz#3a7deeabbb8c030d4126b24f84e525466145872e"
+  integrity sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==
+  dependencies:
+    "@ethersproject/abi" "5.7.0"
+    "@ethersproject/abstract-provider" "5.7.0"
+    "@ethersproject/abstract-signer" "5.7.0"
+    "@ethersproject/address" "5.7.0"
+    "@ethersproject/base64" "5.7.0"
+    "@ethersproject/basex" "5.7.0"
+    "@ethersproject/bignumber" "5.7.0"
+    "@ethersproject/bytes" "5.7.0"
+    "@ethersproject/constants" "5.7.0"
+    "@ethersproject/contracts" "5.7.0"
+    "@ethersproject/hash" "5.7.0"
+    "@ethersproject/hdnode" "5.7.0"
+    "@ethersproject/json-wallets" "5.7.0"
+    "@ethersproject/keccak256" "5.7.0"
+    "@ethersproject/logger" "5.7.0"
+    "@ethersproject/networks" "5.7.1"
+    "@ethersproject/pbkdf2" "5.7.0"
+    "@ethersproject/properties" "5.7.0"
+    "@ethersproject/providers" "5.7.2"
+    "@ethersproject/random" "5.7.0"
+    "@ethersproject/rlp" "5.7.0"
+    "@ethersproject/sha2" "5.7.0"
+    "@ethersproject/signing-key" "5.7.0"
+    "@ethersproject/solidity" "5.7.0"
+    "@ethersproject/strings" "5.7.0"
+    "@ethersproject/transactions" "5.7.0"
+    "@ethersproject/units" "5.7.0"
+    "@ethersproject/wallet" "5.7.0"
+    "@ethersproject/web" "5.7.1"
+    "@ethersproject/wordlists" "5.7.0"
 
 eventemitter3@^4.0.0, eventemitter3@^4.0.7:
   version "4.0.7"
@@ -5603,7 +5991,7 @@ hash-base@^3.0.0:
     readable-stream "^3.6.0"
     safe-buffer "^5.2.0"
 
-hash.js@^1.0.0, hash.js@^1.0.3:
+hash.js@1.1.7, hash.js@^1.0.0, hash.js@^1.0.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/hash.js/-/hash.js-1.1.7.tgz#0babca538e8d4ee4a0f8988d68866537a003cf42"
   integrity sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==
@@ -6872,6 +7260,11 @@ jest@26.6.0:
     "@jest/core" "^26.6.0"
     import-local "^3.0.2"
     jest-cli "^26.6.0"
+
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -9804,6 +10197,11 @@ schema-utils@^3.0.0, schema-utils@^3.1.1:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
+scrypt-js@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz#d314a57c2aef69d1ad98a138a21fe9eafa9ee312"
+  integrity sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==
+
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
@@ -11583,6 +11981,11 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
+
+ws@7.4.6:
+  version "7.4.6"
+  resolved "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
+  integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
 ws@^6.2.1:
   version "6.2.2"


### PR DESCRIPTION
# Description

Updated the developer tools and added support for the following EVM actions:

- `eth_signTypedData`
- `eth_signTypedData_v3`
- `eth_signTypedData_v4`
- Revoking ERC20
- Approving / Revoking ERC20 spending
- Approving / Revoking ERC721 spending
- Approving / Revoking ERC1155 spending

These methods would not make it necessary to use other dapps (uniswap / revoke.cash) for testing purposes.

Also using `ethers` for some methods as that's what most developers will be using when creating dApps. So I thought it would be good to test against this.

- Updated the mobile screens and reduced log space


## Screenshot
![image](https://user-images.githubusercontent.com/615509/213760473-fee36c15-6a4b-43b0-9e07-069e86165ae6.png)
![image](https://user-images.githubusercontent.com/615509/213990007-2cdc6ba2-4e1e-48f7-be16-16b7c470779b.png)

